### PR TITLE
Fix CircleCI indicator so it points at new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # datacats
 
-[![Circle CI](https://circleci.com/gh/boxkite/datacats.svg?style=svg)](https://circleci.com/gh/boxkite/datacats)
+[![Circle CI](https://circleci.com/gh/datacats/datacats.svg?style=svg)](https://circleci.com/gh/boxkite/datacats)
 
 datacats uses Docker to give you fully self-contained [CKAN](http://ckan.org) dev environments on
 any platform, along with a command to deploy that exact environment to the cloud.


### PR DESCRIPTION
(It still pointed at boxkite/datacats, which doesn't exist anymore)