### PR TITLE
Rewrite cli entry point to support reporting errors with exceptions

### DIFF
--- a/datacats/cli/deploy.py
+++ b/datacats/cli/deploy.py
@@ -43,7 +43,7 @@ the environment name.
         if not profile.create(environment, target_name, stdout):
             return 1
 
-    profile.deploy(environment, target_name, stdout):
+    profile.deploy(environment, target_name, stdout)
     print "Deployed source to http://{0}.datacats.io".format(target_name)
 
     if opts['--create']:

--- a/datacats/cli/deploy.py
+++ b/datacats/cli/deploy.py
@@ -43,9 +43,7 @@ the environment name.
         if not profile.create(environment, target_name, stdout):
             return 1
 
-    if not profile.deploy(environment, target_name, stdout):
-        return 1
-
+    profile.deploy(environment, target_name, stdout):
     print "Deployed source to http://{0}.datacats.io".format(target_name)
 
     if opts['--create']:

--- a/datacats/cli/main.py
+++ b/datacats/cli/main.py
@@ -4,7 +4,6 @@
 # the terms of the GNU Affero General Public License version 3.0.
 # See LICENSE.txt or http://www.fsf.org/licensing/licenses/agpl-3.0.html
 
-
 """datacats command line interface
 
 Usage:
@@ -92,11 +91,8 @@ def _parse_arguments(args):
             help_ = True
             continue
         if a not in COMMANDS:
-            raise DatacatsError(
-                "\'{0}\' command is not recognized. \n"
-                "See \'datacats help\' for the list of"
-                " available commands".format(a)
-            )
+            raise DatacatsError("\'{0}\' command is not recognized. \n \
+          See \'datacats help\' for the list of available commands".format(a))
         command_fn = COMMANDS[a]
         break
     else:

--- a/datacats/cli/main.py
+++ b/datacats/cli/main.py
@@ -4,6 +4,7 @@
 # the terms of the GNU Affero General Public License version 3.0.
 # See LICENSE.txt or http://www.fsf.org/licensing/licenses/agpl-3.0.html
 
+
 """datacats command line interface
 
 Usage:
@@ -68,62 +69,67 @@ def main():
     and runs the corresponding command
     """
     try:
-      command_fn, opts = _parse_arguments(sys.argv[1:])
-      # purge handles loading differently
-      if command_fn != purge.purge and 'ENVIRONMENT' in opts:
-          environment = Environment.load(opts['ENVIRONMENT'] or '.')
-          return command_fn(environment, opts)
-      return command_fn(opts)
+        command_fn, opts = _parse_arguments(sys.argv[1:])
+        # purge handles loading differently
+        if command_fn != purge.purge and 'ENVIRONMENT' in opts:
+            environment = Environment.load(opts['ENVIRONMENT'] or '.')
+            return command_fn(environment, opts)
+        return command_fn(opts)
     except DatacatsError as e:
         print e
         sys.exit(1)
 
 
 def _parse_arguments(args):
-  help_ = False # flag for only showing the help message
+    help_ = False  # flag for only showing the help message
 
-  # Find subcommand without docopt so that subcommand options may appear anywhere
-  for i, a in enumerate(args):
-      if a.startswith('-'):
-          continue
-      if a == 'help':
-          help_ = True
-          continue
-      if a not in COMMANDS:
-        raise DatacatsError("\'{0}\' command is not recognized. \n \
-          See \'datacats help\' for the list of available commands".format(a))
-      command_fn = COMMANDS[a]
-      break
-  else:
-    return _intro_message, {}
+    # Find subcommand without docopt so that subcommand options may appear
+    # anywhere
+    for i, a in enumerate(args):
+        if a.startswith('-'):
+            continue
+        if a == 'help':
+            help_ = True
+            continue
+        if a not in COMMANDS:
+            raise DatacatsError(
+                "\'{0}\' command is not recognized. \n"
+                "See \'datacats help\' for the list of"
+                " available commands".format(a)
+            )
+        command_fn = COMMANDS[a]
+        break
+    else:
+        return _intro_message, {}
 
-  # shell, paster are special: options might belong to the command being
-  # executed
-  if command_fn == shell.shell:
-      # assume commands don't start with '-' and that those options
-      # are intended for datacats
-      for j, a in enumerate(args[i + 2:], i + 2):
-          if not a.startswith('-'):
-              # -- makes docopt parse the rest as positional args
-              args = args[:j] + ['--'] + args[j:]
-              break
+    # shell, paster are special: options might belong to the command being
+    # executed
+    if command_fn == shell.shell:
+        # assume commands don't start with '-' and that those options
+        # are intended for datacats
+        for j, a in enumerate(args[i + 2:], i + 2):
+            if not a.startswith('-'):
+                # -- makes docopt parse the rest as positional args
+                args = args[:j] + ['--'] + args[j:]
+                break
 
-  if command_fn == shell.paster:
-      args = args[:i + 1] + ['--'] + args[i + 1:]
+    if command_fn == shell.paster:
+        args = args[:i + 1] + ['--'] + args[i + 1:]
 
-  if help_:
-      args.insert(1, '--help')
+    if help_:
+        args.insert(1, '--help')
 
-  opts = docopt(command_fn.__doc__, args)
-  _option_not_yet_implemented(opts, '--ckan')
-  _option_not_yet_implemented(opts, '--remote')
-  return command_fn, opts
+    opts = docopt(command_fn.__doc__, args)
+    _option_not_yet_implemented(opts, '--ckan')
+    _option_not_yet_implemented(opts, '--remote')
+    return command_fn, opts
 
 
 def _option_not_yet_implemented(opts, name):
     if name not in opts or not opts[name]:
         return
-    raise DatacatsError("\'{0}\' option is not implemented yet. \n".format(name))
+    raise DatacatsError(
+        "\'{0}\' option is not implemented yet. \n".format(name))
 
 
 def _intro_message(opts):

--- a/datacats/cli/profile.py
+++ b/datacats/cli/profile.py
@@ -7,6 +7,8 @@
 from os.path import exists
 
 from datacats.userprofile import UserProfile
+from datacats.environment import DatacatsError
+
 
 def get_working_profile(environment):
     """
@@ -15,31 +17,28 @@ def get_working_profile(environment):
     user interactively.
     """
     profile = UserProfile()
+    if not (profile.ssh_private_key is None) and \
+        exists(profile.ssh_private_key) and \
+        exists(profile.ssh_public_key):
+        key_recognized = profile.test_ssh_key(environment)
+        if key_recognized:
+            # we sucessfully loaded the ssh key and tested it by connecting to the server, so all is good and
+            # we have got ourselves a working profile
+            return profile
 
-    new_key = False
-    if profile.ssh_private_key is None or not exists(
-            profile.ssh_private_key) or not exists(profile.ssh_public_key):
-        new_key = _create_profile(profile)
+        user_error_message = """Your ssh key (which is an equivalent of your password so that datacats.io could recognize you) does not
+        does not seem to be recognized by the datacats.io server.\n \n
+        Most likely it is because you need to go to www.datacats.com/account/key and add the following public key: \n \n {public_key} \n \n
+        to your profile so that datacat's server could recognize you. So maybe try that?
+        If the problem persists, please contact the developer team.""".format(public_key=profile.read_public_key())
+        raise  DatacatsError(user_error_message)
 
-    if new_key:
-        print 'New key generated. Please visit'
-        print 'https://www.datacats.com/account/key'
-        print 'and paste your public key in to the form:'
+    new_key = _create_profile(profile)
+    user_error_message = """Your profile does not seem to have an ssh key (which is an equivalent of your password so that datacats.io could recognize you).
+            So we generated a new ssh key for you. Please go to www.datacats.com/account/key and add the following public key: \n \n {public_key} \n \n to your profile.
+            """.format(public_key=profile.read_public_key())
+    raise DatacatsError(user_error_message)
 
-    if not new_key and not profile.test_ssh_key(environment):
-        print 'There was an error connecting to DataCats.com'
-        print 'If you have not installed your key please visit'
-        print 'https://www.datacats.com/account/key'
-        print 'and paste your public key in to the form:'
-        new_key = True
-
-    if new_key:
-        print
-        with open(profile.ssh_public_key) as pub_key:
-            print pub_key.read()
-        return
-
-    return profile
 
 def _create_profile(profile):
     """

--- a/datacats/cli/profile.py
+++ b/datacats/cli/profile.py
@@ -20,24 +20,13 @@ def get_working_profile(environment):
     if not (profile.ssh_private_key is None) and \
         exists(profile.ssh_private_key) and \
         exists(profile.ssh_public_key):
-        key_recognized = profile.test_ssh_key(environment)
-        if key_recognized:
-            # we sucessfully loaded the ssh key and tested it by connecting to the server, so all is good and
-            # we have got ourselves a working profile
-            return profile
-
-        user_error_message = """Your ssh key (which is an equivalent of your password so that datacats.io could recognize you) does not
-        does not seem to be recognized by the datacats.io server.\n \n
-        Most likely it is because you need to go to www.datacats.com/account/key and add the following public key: \n \n {public_key} \n \n
-        to your profile so that datacat's server could recognize you. So maybe try that?
-        If the problem persists, please contact the developer team.""".format(public_key=profile.read_public_key())
-        raise  DatacatsError(user_error_message)
+        profile.test_ssh_key(environment)
+        # we sucessfully loaded the ssh key and tested it by connecting to the server,
+        #so all is good at this point and
+        # we have got ourselves a working profile
+        return profile
 
     new_key = _create_profile(profile)
-    user_error_message = """Your profile does not seem to have an ssh key (which is an equivalent of your password so that datacats.io could recognize you).
-            So we generated a new ssh key for you. Please go to www.datacats.com/account/key and add the following public key: \n \n {public_key} \n \n to your profile.
-            """.format(public_key=profile.read_public_key())
-    raise DatacatsError(user_error_message)
 
 
 def _create_profile(profile):
@@ -50,9 +39,9 @@ def _create_profile(profile):
     profile.ssh_private_key = profile.profiledir + '/id_rsa'
     profile.ssh_public_key = profile.profiledir + '/id_rsa.pub'
     profile.save()
-
-    if exists(profile.ssh_private_key):
-        return False
     profile.generate_ssh_key()
-    return True
+    user_error_message = ("Your profile does not seem to have an ssh key (which is an equivalent of your password so that datacats.io could recognize you)."
+        "So we generated a new ssh key for you. Please go to www.datacats.com/account/key and add the following public key:"
+        " \n \n {public_key} \n \n to your profile.").format(public_key=profile.read_public_key())
+    raise DatacatsError(user_error_message)
 

--- a/datacats/userprofile.py
+++ b/datacats/userprofile.py
@@ -31,6 +31,14 @@ class UserProfile(object):
             self.ssh_private_key = None
             self.ssh_public_key = None
 
+    def read_public_key(self):
+        """
+        Read public key from file and reuturn as a string
+        """
+        with open(self.ssh_public_key) as pub_key:
+            return pub_key.read()
+
+
     def save(self):
         """
         Save profile settings into user profile directory
@@ -47,6 +55,8 @@ class UserProfile(object):
 
         with open(config, 'w') as cfile:
             cp.write(cfile)
+
+
 
     def generate_ssh_key(self):
         """

--- a/datacats/userprofile.py
+++ b/datacats/userprofile.py
@@ -70,7 +70,7 @@ class UserProfile(object):
                          getuser(), gethostname()),
                      "-f", "/output/id_rsa"],
             rw={self.profiledir: '/output'},
-        )
+            )
 
     def test_ssh_key(self, project):
         """
@@ -86,7 +86,7 @@ class UserProfile(object):
                     SSH_CONFIG: '/etc/ssh/ssh_config',
                     self.profiledir + '/id_rsa': '/root/.ssh/id_rsa'},
                 clean_up=True
-            )
+                )
             return True
         except WebCommandError as e:
             user_error_message = (
@@ -100,7 +100,7 @@ class UserProfile(object):
                 "to your profile so that datacat's server could recognize you."
                 " So maybe try that?\n"
                 "If the problem persists, please contact the developer team."
-            ).format(public_key=self.read_public_key())
+                ).format(public_key=self.read_public_key())
 
             user_error_message += "\n[" + e.__str__() + "]"
             raise DatacatsError(user_error_message)
@@ -113,13 +113,13 @@ class UserProfile(object):
             web_command(
                 command=[
                     "ssh", _project_user_host(project), "create", target_name,
-                ],
+                    ],
                 ro={KNOWN_HOSTS: '/root/.ssh/known_hosts',
                     SSH_CONFIG: '/etc/ssh/ssh_config',
                     self.profiledir + '/id_rsa': '/root/.ssh/id_rsa'},
                 stream_output=stream_output,
                 clean_up=True,
-            )
+                )
             return True
         except WebCommandError:
             return False
@@ -133,12 +133,12 @@ class UserProfile(object):
                 command=[
                     "ssh", _project_user_host(project),
                     "admin_password", target_name, password,
-                ],
+                    ],
                 ro={KNOWN_HOSTS: '/root/.ssh/known_hosts',
                     SSH_CONFIG: '/etc/ssh/ssh_config',
                     self.profiledir + '/id_rsa': '/root/.ssh/id_rsa'},
                 clean_up=True,
-            )
+                )
             return True
         except WebCommandError:
             return False
@@ -162,17 +162,17 @@ class UserProfile(object):
                     self.profiledir + '/id_rsa': '/root/.ssh/id_rsa'},
                 stream_output=stream_output,
                 clean_up=True,
-            )
+                )
             web_command(
                 command=[
                     "ssh", _project_user_host(project), "install", target_name,
-                ],
+                    ],
                 ro={KNOWN_HOSTS: '/root/.ssh/known_hosts',
                     SSH_CONFIG: '/etc/ssh/ssh_config',
                     self.profiledir + '/id_rsa': '/root/.ssh/id_rsa'},
                 stream_output=stream_output,
                 clean_up=True,
-            )
+                )
             return True
         except WebCommandError:
             return False


### PR DESCRIPTION
We have two types of errors:
1) "user errors" where the requested action cannot be performed and the user needs to receive the explaining message on why this is the case
2) "programming errors" where we have unintended behaviour which should be fixed

The Pythonic way is to raise an Exception and let it propagate all the way up the stack. We then catch that Exception within the entry point (main.py:main) and show the detailed error message to the user.

The two types of Exceptions will correspond to the two types of errors:
1) `DataCatsError` class instances and its children for "user errors"
2) All the other exceptions will their specific types for "programming errors"

Returning 1 and 0 codes for errors leads to confusing user experience where error messages are not very helpful and we probably should move away from that.