### PR TITLE
Fix issue where lazy instantiation still referred to old name for a variable

### DIFF
--- a/datacats/docker.py
+++ b/datacats/docker.py
@@ -78,7 +78,7 @@ def _get_docker():
             # workaround for connection issue when old version specified
             # on some clients
             version_client = Client(**_docker_kwargs)
-            api_version = _version_client.version()['ApiVersion']
+            api_version = version_client.version()['ApiVersion']
 
         version = get_api_version(DEFAULT_DOCKER_API_VERSION, api_version)
         _docker = Client(version=version, **_docker_kwargs)


### PR DESCRIPTION
This would cause a failure if something like #81 were to occur.