### PR TITLE
Add a command to watch less files

### DIFF
--- a/datacats/cli/lesscd.py
+++ b/datacats/cli/lesscd.py
@@ -1,0 +1,50 @@
+"""
+Watches a CKAN environment for changes in its .less files, and recompiles them when they do.
+
+Usage:
+  datacats-lesscd [--help] TARGET
+
+  --help -h         Show this help and quit.
+"""
+
+from os.path import expanduser, join as path_join
+import signal
+
+from docopt import docopt
+from datacats.version import __version__
+from datacats.environment import Environment
+from datacats.cli.less import less
+
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler, FileModifiedEvent
+
+
+# None to start off with, defined in main()
+environment = None
+
+
+class LessCompileEventHandler(FileSystemEventHandler):
+    def __init__(self, environment):
+        self.environment = environment
+
+    def on_modified(self, event):
+        if isinstance(event, FileModifiedEvent):
+            print 'event! ' + str(event)
+            less(self.environment, {})
+
+
+def main():
+    opts = docopt(__doc__, version=__version__)
+    env_path = expanduser(opts['TARGET'])
+    environment = Environment.load(env_path)
+    # Path to less files in ckan. This is the path we're gonna watch.
+    less_path = path_join(env_path, 'ckan', 'ckan', 'public', 'base', 'less')
+    observer = Observer()
+    event_handler = LessCompileEventHandler(environment)
+    observer.schedule(event_handler, less_path, recursive=True)
+    observer.start()
+
+    # HACK: We make it so that the OS doesn't consult us and just kills us.
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+    observer.join()

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -1,6 +1,7 @@
 Command Reference
 =================
-
+datacats
+~~~~~~~~
 help
 ----
 .. program-output:: datacats help
@@ -68,3 +69,7 @@ stop
 less
 ----
 .. program-output:: datacats help less
+
+datacats-lesscd
+~~~~~~~~~~~~~~~
+.. program-output:: datacats-lesscd --help

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ install_requires = [
     'docker-py>=1.1.0',
     'clint',  # to output colored text to terminal
     'requests>=2.5.2',  # help with docker-py requirement
+    'watchdog' # For lesscd
 ]
 
 exec(open("datacats/version.py").read())
@@ -39,5 +40,6 @@ setup(
     entry_points="""
         [console_scripts]
         datacats=datacats.cli.main:main
+        datacats-lesscd=datacats.cli.lesscd:main
         """,
     )


### PR DESCRIPTION
You can now run 'datacats-lesscd' to watch less files in a given CKAN source
directory. This command takes a source directory (the source root) as its
only parameter.

This fixes #118.