### PR TITLE
Add a little test to identify issues with docker connection

### DIFF
--- a/datacats/tests/test_docker.py
+++ b/datacats/tests/test_docker.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+from docker.utils import kwargs_from_env
+from docker.client import Client
+
+
+class TestOpenSSLBug(TestCase):
+    """
+      Tests if communication between Docker and datacats fails
+      (There could be various reasons for that like:
+         1) Docker not installed properly
+         2) Docker's envvariable not set up
+         3) that weird bug one gets on MacOSX
+         (see https://github.com/datacats/datacats/issues/63)
+
+      None of these are really datacats issue per ce,
+      still, should be useful
+    """
+
+    def test_docker_connection(self):
+        try:
+            kwargs = kwargs_from_env()
+            client = Client(**kwargs)
+            client.version()
+        except Exception as e:
+            self.fail("Cannot connect to Docker: " + e.__str__())


### PR DESCRIPTION
This little test blows up when connection to the docker is broken. Which can be an indicator of issues like:
1) test environment not being set properly
2)  [this bug](https://github.com/docker/docker-py/issues/465) showing up again

