### PR TITLE
Catch and wrap with user-friendly message all unspecified Errors

### DIFF
--- a/datacats/cli/main.py
+++ b/datacats/cli/main.py
@@ -34,14 +34,16 @@ See 'datacats help COMMAND' for information about options and
 arguments available to each command.
 """
 
-import sys, traceback
-from docopt import docopt
 
+import sys
+import traceback
+from docopt import docopt
 from datacats.cli import create, manage, install, pull, purge, shell, deploy, migrate, less
 from datacats.environment import Environment
 from datacats.error import DatacatsError, UndocumentedError
 from datacats.userprofile import UserProfile
 from datacats.version import __version__
+
 
 COMMANDS = {
     'create': create.create,
@@ -77,6 +79,7 @@ def main():
     It parses the cli arguments for corresponding options
     and runs the corresponding command
     """
+    # pylint: disable=bare-except
     try:
         command_fn, opts = _parse_arguments(sys.argv[1:])
         # purge handles loading differently
@@ -99,34 +102,33 @@ def main():
         return command_fn(environment, opts, user_profile)
 
     except DatacatsError as e:
-            _error_exit(e)
-    except Exception:
-            a,b, c = sys.exc_info()
-            exc_info = "\n".join([line.rstrip() for line in traceback.format_exception(a,b,c)])
-            user_message = ("Something that should not"
-                " have happened happened when attempting"
-                " to run this command:\n"
-                "     datacats {args}\n\n"
-                "It is seems to be a bug.\n"
-                "Please report this issue to us by"
-                " creating an issue ticket at\n\n"
-                "    https://github.com/datacats/datacats/issues\n\n"
-                "so that we would be able to look into that "
-                "and fix the issue."
-                ).format(args=" ".join(sys.argv[1:]))
+        _error_exit(e)
+    except:
+        exc_info = "\n".join([line.rstrip()
+            for line in traceback.format_exception(*sys.exc_info())])
+        user_message = ("Something that should not"
+            " have happened happened when attempting"
+            " to run this command:\n"
+            "     datacats {args}\n\n"
+            "It is seems to be a bug.\n"
+            "Please report this issue to us by"
+            " creating an issue ticket at\n\n"
+            "    https://github.com/datacats/datacats/issues\n\n"
+            "so that we would be able to look into that "
+            "and fix the issue."
+            ).format(args=" ".join(sys.argv[1:]))
 
-
-            _error_exit( DatacatsError(user_message,
-                parent_exception=UndocumentedError(exc_info)))
+        _error_exit(DatacatsError(user_message,
+            parent_exception=UndocumentedError(exc_info)))
 
 
 def _error_exit(exception):
-        if sys.stdout.isatty():
-            # error message to have colors if stdout goes to shell
-            exception.pretty_print()
-        else:
-            print exception
-        sys.exit(1)
+    if sys.stdout.isatty():
+        # error message to have colors if stdout goes to shell
+        exception.pretty_print()
+    else:
+        print exception
+    sys.exit(1)
 
 
 def _parse_arguments(args):

--- a/datacats/cli/main.py
+++ b/datacats/cli/main.py
@@ -103,18 +103,21 @@ def main():
     except Exception:
             a,b, c = sys.exc_info()
             exc_info = "\n".join([line.rstrip() for line in traceback.format_exception(a,b,c)])
-
-            _error_exit(
-                DatacatsError(("Something that should not"
-                " have happened happened when attempting to run this command:\n"
+            user_message = ("Something that should not"
+                " have happened happened when attempting"
+                " to run this command:\n"
                 "     datacats {args}\n\n"
                 "It is seems to be a bug.\n"
-                "Please report this issue to us by creating an issue ticket at\n\n"
+                "Please report this issue to us by"
+                " creating an issue ticket at\n\n"
                 "    https://github.com/datacats/datacats/issues\n\n"
                 "so that we would be able to look into that "
                 "and fix the issue."
-            ).format(args=" ".join(sys.argv[1:])),
-            parent_exception=UndocumentedError(exc_info)))
+                ).format(args=" ".join(sys.argv[1:]))
+
+
+            _error_exit( DatacatsError(user_message,
+                parent_exception=UndocumentedError(exc_info)))
 
 
 def _error_exit(exception):

--- a/datacats/cli/main.py
+++ b/datacats/cli/main.py
@@ -34,11 +34,12 @@ See 'datacats help COMMAND' for information about options and
 arguments available to each command.
 """
 
-import sys
+import sys, traceback
 from docopt import docopt
 
 from datacats.cli import create, manage, install, pull, purge, shell, deploy, migrate, less
-from datacats.environment import Environment, DatacatsError
+from datacats.environment import Environment
+from datacats.error import DatacatsError, UndocumentedError
 from datacats.userprofile import UserProfile
 from datacats.version import __version__
 
@@ -98,11 +99,30 @@ def main():
         return command_fn(environment, opts, user_profile)
 
     except DatacatsError as e:
+            _error_exit(e)
+    except Exception:
+            a,b, c = sys.exc_info()
+            exc_info = "\n".join([line.rstrip() for line in traceback.format_exception(a,b,c)])
+
+            _error_exit(
+                DatacatsError(("Something that should not"
+                " have happened happened when attempting to run this command:\n"
+                "     datacats {args}\n\n"
+                "It is seems to be a bug.\n"
+                "Please report this issue to us by creating an issue ticket at\n\n"
+                "    https://github.com/datacats/datacats/issues\n\n"
+                "so that we would be able to look into that "
+                "and fix the issue."
+            ).format(args=" ".join(sys.argv[1:])),
+            parent_exception=UndocumentedError(exc_info)))
+
+
+def _error_exit(exception):
         if sys.stdout.isatty():
             # error message to have colors if stdout goes to shell
-            e.pretty_print()
+            exception.pretty_print()
         else:
-            print e
+            print exception
         sys.exit(1)
 
 

--- a/datacats/cli/main.py
+++ b/datacats/cli/main.py
@@ -103,6 +103,9 @@ def main():
 
     except DatacatsError as e:
         _error_exit(e)
+    except SystemExit:
+        # datacats --version raises SystemExit to quit
+        sys.exit(0)
     except:
         exc_info = "\n".join([line.rstrip()
             for line in traceback.format_exception(*sys.exc_info())])

--- a/datacats/docker.py
+++ b/datacats/docker.py
@@ -7,7 +7,7 @@
 from __future__ import absolute_import
 
 from os import environ, devnull
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
+from requests.packages.urllib3.exceptions import InsecureRequestWarning, InsecurePlatformWarning
 import json
 import subprocess
 import tempfile
@@ -80,6 +80,7 @@ def _get_docker():
             import warnings
             # It will print out messages to the user otherwise.
             warnings.filterwarnings("ignore", category=InsecureRequestWarning)
+            warnings.filterwarnings("ignore", category=InsecurePlatformWarning)
             _docker_kwargs['tls'].verify = False
 
         # Create the Docker client

--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -418,7 +418,7 @@ class Environment(object):
             # This should take care if the 'site' subdir if needed
             makedirs(self.sitedir, mode=0o700)
         except OSError:
-            raise DatacatsError('Site environment {} already exists.'.format(self.site_name))
+            raise DatacatsError('Site directory {} already exists.'.format(self.name + "/" + self.site_name))
         # venv isn't site-specific, the rest are.
         makedirs(self.sitedir + '/search')
         if not is_boot2docker():

--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -418,7 +418,9 @@ class Environment(object):
             # This should take care if the 'site' subdir if needed
             makedirs(self.sitedir, mode=0o700)
         except OSError:
-            raise DatacatsError('Site directory {} already exists.'.format(self.name + "/" + self.site_name))
+            raise DatacatsError(("Site directory {}"
+                " already exists.")
+                .format(self.name + "/" + self.site_name))
         # venv isn't site-specific, the rest are.
         makedirs(self.sitedir + '/search')
         if not is_boot2docker():
@@ -998,7 +1000,6 @@ class Environment(object):
         return web_command(command=command, ro=ro, rw=rw, links=links,
                            volumes_from=volumes_from, clean_up=clean_up,
                            commit=True, stream_output=stream_output)
-
 
     def purge_data(self, which_sites=None, never_delete=False):
         """

--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -995,14 +995,10 @@ class Environment(object):
         else:
             links = None
 
-        try:
-            return web_command(command=command, ro=ro, rw=rw, links=links,
-                               volumes_from=volumes_from, clean_up=clean_up,
-                               commit=True, stream_output=stream_output)
-        except WebCommandError as e:
-            print ('Failed to run command %s.'
-                ' Logs are as follows:\n%s') % (e.command, e.logs)
-            raise
+        return web_command(command=command, ro=ro, rw=rw, links=links,
+                           volumes_from=volumes_from, clean_up=clean_up,
+                           commit=True, stream_output=stream_output)
+
 
     def purge_data(self, which_sites=None, never_delete=False):
         """

--- a/datacats/error.py
+++ b/datacats/error.py
@@ -11,11 +11,11 @@ class DatacatsError(Exception):
                 "type_description": parent_exception.user_description,
                 "message": parent_exception.__str__(),
             }
-            self.message = "".join(["{original}\n\n",
+            self.message = "".join([colored.blue("{original}\n\n").__str__(),
                                     "~" * 30,
                                     "\n{type_description}:\n",
-                                    "{message}",
-                                    "~" * 30, "\n"]).format(**vals)
+                                    colored.yellow("{message}\n").__str__()]
+                                    ).format(**vals)
 
         self.format_args = format_args
         super(DatacatsError, self).__init__(message, format_args)
@@ -29,8 +29,7 @@ class DatacatsError(Exception):
         """
         print colored.blue("-" * 40)
         print colored.red("datacats: problem was encountered:")
-        for line in self.message.format(*self.format_args).split('\n'):
-            print "    ", line
+        print self.message.format(*self.format_args)
         print colored.blue("-" * 40)
 
 

--- a/datacats/error.py
+++ b/datacats/error.py
@@ -50,3 +50,6 @@ class WebCommandError(Exception):
 
 class PortAllocatedError(Exception):
     user_description = "Unable to allocate port"
+
+class UndocumentedError(Exception):
+    user_description = "Please quote this traceback when reporting this error"

--- a/datacats/error.py
+++ b/datacats/error.py
@@ -9,12 +9,12 @@ class DatacatsError(Exception):
             vals = {
                 "original": self.message,
                 "type_description": parent_exception.user_description,
-                "message": parent_exception.__str__(),
+                "message": str(parent_exception),
             }
-            self.message = "".join([colored.blue("{original}\n\n").__str__(),
+            self.message = "".join([str(colored.blue("{original}\n\n")),
                                     "~" * 30,
                                     "\n{type_description}:\n",
-                                    colored.yellow("{message}\n").__str__()]
+                                    str(colored.yellow("{message}\n"))]
                                     ).format(**vals)
 
         self.format_args = format_args

--- a/datacats/error.py
+++ b/datacats/error.py
@@ -51,5 +51,6 @@ class WebCommandError(Exception):
 class PortAllocatedError(Exception):
     user_description = "Unable to allocate port"
 
+
 class UndocumentedError(Exception):
     user_description = "Please quote this traceback when reporting this error"


### PR DESCRIPTION
When unspecified (programming) error is encountered, we output an error message like this that prompts the user to report it here as an issue:


![Img](https://cloud.githubusercontent.com/assets/816895/8095201/69bb090a-0f9a-11e5-928c-9860514abe59.png)

Before it was just spilling out the traceback as it is.