### PR TITLE
Update Install instructions on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@ any platform, along with a command to deploy that exact environment to the cloud
 
 
 ## Install
+Please see detailed OS-specific [installation instructions in the docs](http://docs.datacats.com/guide.html#installation).
 
-OSX | Linux | Windows
---- | --- | ---
-1. [Install boot2docker](https://docs.docker.com/installation/mac/) | 1. [Install latest docker](https://docs.docker.com/installation/ubuntulinux/#docker-maintained-package-installation) | coming soon
-2. run `pip install datacats` | 2. run `pip install datacats` |
-3. run `datacats pull` | 3. run `datacats pull` |
-
-See the full docs at [docs.datacats.com](http://docs.datacats.com)
+If you are considering contributing to datacats development,
+or would like to ruse a custom branch, install directly from this repository:
+```
+git clone git@github.com:datacats/datacats.git
+python setup.py develop
+```
+You will still need to install Docker and run `datacats pull` afterwards.
 
 ## Create a CKAN environment
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,6 @@ any platform, along with a command to deploy that exact environment to the cloud
 ## Install
 Please see detailed OS-specific [installation instructions in the docs](http://docs.datacats.com/guide.html#installation).
 
-If you are considering contributing to datacats development,
-or would like to ruse a custom branch, install directly from this repository:
-```
-git clone git@github.com:datacats/datacats.git
-python setup.py develop
-```
-You will still need to install Docker and run `datacats pull` afterwards.
 
 ## Create a CKAN environment
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -98,9 +98,22 @@ That is it, you are all set!
 
 Install from source
 """""""""""""""""""""
-To pull the Docker images run::
+A more advanced option is to install datacats directly from the source code.
+
+This option may be needed if are considering contributing to the datacats development
+or would like to try the most recent (and potentially unstable) version.
+
+To install datacats directly from the `source code repository on Github`_,
+clone the source repo to your custom location and
+install datacats as a Python package from there: ::
+
+  git clone git@github.com:datacats/datacats.git
+  python setup.py develop
+
+You will still need to download the necessary Docker images as described above.
 
 
+.. _source code repository on Github: https://github.com/datacats/datacats
 
 Getting Started
 ---------------

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -34,12 +34,12 @@ Virtual Machine. Simply install VirtualBox or VMWare, create a Ubuntu VM (Virtua
 Install Docker
 """"""""""""""
 You will need to install Docker first.
-OS-specific detailed reference on how to do that is available at the
+Detailed OS-specific reference on how to do that is available at the
 `Installation Instructions section on Docker site`_ .
 
 .. _Installation Instructions section on Docker site: https://docs.docker.com/installation/#installation
 
-Here is the quick OS-specific summary:
+Here is the quick OS-specific summary that is sufficient in most cases:
 
 Linux
 #####
@@ -80,17 +80,26 @@ If you do not have ``pip`` installed, you can install it first by running: ::
 
     easy_install pip
 
+.. _`Download the necessary Docker containers`:
+
+
+Download the necessary Docker containers
+"""""""""""""""""""""
+
 As a last setup step, we need to pull the Docker images needed to
 create your environment. This only needs to happen **once**. Those images are
 then re-used for all subsequent environments you create.
 
-.. _`Download the necessary Docker containers`:
+To pull the Docker images just run::
 
-Download the necessary Docker containers
+    datacats pull
+
+That is it, you are all set!
+
+Install from source
 """""""""""""""""""""
 To pull the Docker images run::
 
-    datacats pull
 
 
 Getting Started


### PR DESCRIPTION
Oh, and for the Installation section on README.md it probably should:
- point people who want to just use datacats at the doc page
- point people who want to hack datacats to `python setup.py develop` 