### PR TITLE
Hotfix: DatacatsError for undocumented exceptions failing in formatting

### DIFF
--- a/datacats/error.py
+++ b/datacats/error.py
@@ -46,10 +46,14 @@ class WebCommandError(Exception):
         self.logs = logs
 
     def __str__(self):
+        serialized_command = " ".join(self.command) \
+                if type(self.command) is list else \
+                str(self.command)
+
         return ('    Command: {0}\n'
                 '    Docker Error Log:\n'
                 '    {1}\n'
-                ).format(" ".join(self.command), self.logs)
+                ).format(serialized_command, self.logs)
 
 
 class PortAllocatedError(Exception):

--- a/datacats/error.py
+++ b/datacats/error.py
@@ -47,8 +47,8 @@ class WebCommandError(Exception):
 
     def __str__(self):
         serialized_command = " ".join(self.command) \
-                if isinstance(self.command, list) else \
-                str(self.command)
+            if isinstance(self.command, list) else \
+            str(self.command)
 
         return ('    Command: {0}\n'
                 '    Docker Error Log:\n'

--- a/datacats/error.py
+++ b/datacats/error.py
@@ -5,7 +5,7 @@ class DatacatsError(Exception):
 
     def __init__(self, message, format_args=(), parent_exception=None):
         try:
-            self.message = message.format(format_args)
+            self.message = message.format(*format_args)
         except (ValueError, KeyError):
             self.message = message
         if parent_exception and hasattr(parent_exception, 'user_description'):

--- a/datacats/error.py
+++ b/datacats/error.py
@@ -6,7 +6,7 @@ class DatacatsError(Exception):
     def __init__(self, message, format_args=(), parent_exception=None):
         try:
             self.message = message.format(format_args)
-        except:
+        except (ValueError, KeyError):
             self.message = message
         if parent_exception and hasattr(parent_exception, 'user_description'):
             vals = {
@@ -21,6 +21,7 @@ class DatacatsError(Exception):
                                     ).format(**vals)
 
         self.format_args = format_args
+        super(DatacatsError, self).__init__(message, format_args)
 
     def __str__(self):
         return self.message

--- a/datacats/error.py
+++ b/datacats/error.py
@@ -47,7 +47,7 @@ class WebCommandError(Exception):
 
     def __str__(self):
         serialized_command = " ".join(self.command) \
-                if type(self.command) is list else \
+                if isinstance(self.command, list) else \
                 str(self.command)
 
         return ('    Command: {0}\n'

--- a/datacats/error.py
+++ b/datacats/error.py
@@ -4,7 +4,10 @@ from clint.textui import colored
 class DatacatsError(Exception):
 
     def __init__(self, message, format_args=(), parent_exception=None):
-        self.message = message
+        try:
+            self.message = message.format(format_args)
+        except:
+            self.message = message
         if parent_exception and hasattr(parent_exception, 'user_description'):
             vals = {
                 "original": self.message,
@@ -18,10 +21,9 @@ class DatacatsError(Exception):
                                     ).format(**vals)
 
         self.format_args = format_args
-        super(DatacatsError, self).__init__(message, format_args)
 
     def __str__(self):
-        return self.message.format(*self.format_args)
+        return self.message
 
     def pretty_print(self):
         """
@@ -29,7 +31,7 @@ class DatacatsError(Exception):
         """
         print colored.blue("-" * 40)
         print colored.red("datacats: problem was encountered:")
-        print self.message.format(*self.format_args)
+        print self.message
         print colored.blue("-" * 40)
 
 


### PR DESCRIPTION
Fixes [issue#190](https://github.com/datacats/datacats/issues/190)

`.format(args)` should be called only once on `DatcatsExeptions.message`. It was not.