### PR TITLE
Hotfix: fix broken function signature for deploy and create

### DIFF
--- a/datacats/cli/deploy.py
+++ b/datacats/cli/deploy.py
@@ -40,7 +40,7 @@ the environment name.
                             .format(target_name=target_name))
 
     if opts['--create']:
-        profile.create(environment, target_name, stdout)
+        profile.create(environment, target_name)
 
     profile.deploy(environment, target_name, stdout)
     print "Deployed source to http://{0}.datacats.io".format(target_name)

--- a/datacats/userprofile.py
+++ b/datacats/userprofile.py
@@ -124,7 +124,7 @@ class UserProfile(object):
                 else user_unrecognized_error_message
             raise DatacatsError(user_error_message, parent_exception=e)
 
-    def create(self, environment, target_name, stream_output=None):
+    def create(self, environment, target_name):
         """
         Sends "create project" command to the remote server
         """
@@ -165,6 +165,7 @@ class UserProfile(object):
                 ],
                 environment, self,
                 include_project_dir=True,
+                stream_output=stream_output,
                 clean_up=True,
                 )
         except WebCommandError as e:

--- a/datacats/userprofile.py
+++ b/datacats/userprofile.py
@@ -124,7 +124,7 @@ class UserProfile(object):
                 else user_unrecognized_error_message
             raise DatacatsError(user_error_message, parent_exception=e)
 
-    def create(self, environment, target_name):
+    def create(self, environment, target_name, stream_output=None):
         """
         Sends "create project" command to the remote server
         """
@@ -149,7 +149,7 @@ class UserProfile(object):
         except WebCommandError:
             return False
 
-    def deploy(self, environment, target_name):
+    def deploy(self, environment, target_name, stream_output=None):
         """
         Return True if deployment was successful
         """


### PR DESCRIPTION
function signature was not matched by the one called in `datacats/cli/deploy.py` for these two functions

So they have been dysfunctional for a while actually 