### PR TITLE
Fix docopt so that it doesn't quit silently on user error

### DIFF
--- a/datacats/cli/main.py
+++ b/datacats/cli/main.py
@@ -105,8 +105,7 @@ def main():
     except DatacatsError as e:
         _error_exit(e)
     except SystemExit:
-        # datacats --version raises SystemExit to quit
-        sys.exit(0)
+        raise
     except:
         exc_info = "\n".join([line.rstrip()
             for line in traceback.format_exception(*sys.exc_info())])


### PR DESCRIPTION
The issue was that we just sys.exit when we get SystemExit (including DocoptExit). DocoptExit does magic to get the usage printed if the message is raised all the way up to __main__.