### PR TITLE
purge --delete-environment was leaving an venv dir

### DIFF
--- a/datacats/cli/purge.py
+++ b/datacats/cli/purge.py
@@ -45,9 +45,8 @@ Default: '.'
     environment.purge_data(sites)
 
     if opts['--delete-environment']:
-        if not environment.target:
+        if environment.target:
+            rmtree(environment.target)
+        else:
             print 'Failed to load environment.',
             print 'Not deleting environment directory.'
-        else:
-            environment.fix_project_permissions()
-            rmtree(environment.target)


### PR DESCRIPTION
because of an unneeded environment.fix_project_permissions() call after the datadir is already gone