### PR TITLE
support extension ckan-galleries

### DIFF
--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -798,8 +798,8 @@ class Environment(object):
 
         if datapusher:
             if 'datapusher' not in self.containers_running():
-                raise DatacatsError(container_logs(self._get_container_name('datapusher'), "all",
-                                                   False, False))
+                raise DatacatsError(container_logs(
+                    self._get_container_name('datapusher'), "all", False, False))
             links[self._get_container_name('datapusher')] = 'datapusher'
 
         try:
@@ -809,8 +809,8 @@ class Environment(object):
                 rw={self.sitedir + '/files': '/var/www/storage',
                     self.sitedir + '/run/development.ini': 
                         '/project/development.ini',
-                    self.sitedir + '/root/.flickr' : 
-                        'var/www/flickrapi-tokencache'},
+                    self.sitedir + 'var/www/flickrapi-tokencache':
+                        '/root/.flickr'},
                 ro=dict({
                     self.target: '/project/',
                     WEB: '/scripts/web.sh'}, **ro),

--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -818,7 +818,7 @@ class Environment(object):
                 name=self._get_container_name('web'),
                 image='datacats/web',
                 rw={self.sitedir + '/files': '/var/www/storage',
-                    self.sitedir + '/run/development.ini': 
+                    self.sitedir + '/run/development.ini':
                         '/project/development.ini',
                     self.sitedir + '/flickrapi-tokencache':
                         '/root/.flickr'},

--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -807,8 +807,10 @@ class Environment(object):
                 name=self._get_container_name('web'),
                 image='datacats/web',
                 rw={self.sitedir + '/files': '/var/www/storage',
-                    self.sitedir + '/run/development.ini':
-                        '/project/development.ini'},
+                    self.sitedir + '/run/development.ini': 
+                        '/project/development.ini',
+                    self.sitedir + '/root/.flickr' : 
+                        'var/www/flickrapi-tokencache'},
                 ro=dict({
                     self.target: '/project/',
                     WEB: '/scripts/web.sh'}, **ro),

--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -809,7 +809,7 @@ class Environment(object):
                 rw={self.sitedir + '/files': '/var/www/storage',
                     self.sitedir + '/run/development.ini': 
                         '/project/development.ini',
-                    self.sitedir + 'var/www/flickrapi-tokencache':
+                    self.sitedir + '/flickrapi-tokencache':
                         '/root/.flickr'},
                 ro=dict({
                     self.target: '/project/',

--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -571,6 +571,17 @@ class Environment(object):
             command='/bin/chown -R www-data: /var/www/storage',
             rw={self.sitedir + '/files': '/var/www/storage'})
 
+    def fix_flickrapi_tokencache_permissions(self):
+        """
+        Set the owner of the flickrapi-tokencache folder to www-data container user
+
+        This folder is required for extensions using the flickrapi,
+        e.g. ckan-galleries
+        """
+        web_command(
+            command='/bin/chown -R www-data: /root/.flickr',
+            rw={self.sitedir + '/flickrapi-tokencache': '/root/.flickr'})
+
     def create_ckan_ini(self):
         """
         Use make-config to generate an initial development.ini file
@@ -989,6 +1000,7 @@ class Environment(object):
             ] + venv_volumes + [
             '-v', self.target + ':/project:rw',
             '-v', self.sitedir + '/files:/var/www/storage:rw',
+            '-v', self.sitedir + '/flickrapi-tokencache:/root/.flickr:rw',
             '-v', script + ':/scripts/shell.sh:ro',
             '-v', PASTER_CD + ':/scripts/paster_cd.sh:ro',
             '-v', self.sitedir + '/run/run.ini:/project/development.ini:ro',

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -23,6 +23,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -q -y install \
         apache2 \
         libapache2-mod-wsgi \
         libgeos-dev \
+        libmysqlclient-dev \
         libcurl4-openssl-dev
 
 #Configure webserver


### PR DESCRIPTION
Addressing #209 

Three hurdles taken, one remaining. I'm posting this PR as point for discussion, although it's not complete.

This should fix the missing mysql_config reported in #201 by adding libmysqlclient-dev to the apt-get install steps in the Dockerfile.

Two additional version conflicts (requests and six, ckan vs ckan-galleries) have to be handled manually until ckan upgrades their versions.

One mean Docker permissions bug remains unsolved.

Steps taken:
```
# create /var/www/projects/datacats so python package requests won't break pip
mkvirtualenv datacats

# Override datacats data dir location to my backed up, bind-mounted btrfs partition at /var/www:
# (before creating a datacats environment)
ln -sf /var/www/projects/datacats/data ~/.datacats

# pull my datacats fork
/var/www/projects/datacats$ git clone git@github.com:florianm/datacats.git
/var/www/projects/datacats/datacats$ python setup.py install

# create a datacats environment
/var/www/projects/datacats$ datacats create modena
/var/www/projects/datacats/modena/

# clone and install datacats into the new environment
/var/www/projects/datacats/modena$ git clone https://github.com/DataShades/ckan-galleries.git
python setup.py install

# modify ckan's requirements to use a ckan-galleries-compatible requests==2.7.0 and six==1.8.0
/var/www/projects/datacats/modena$ vim ckan/requirements.txt

# add ckan-galleries extension name "dfmp" to development.ini
vim /var/www/projects/datacats/modena/development.ini 

# datacats install will not fail anymore on missing mysql_config (fixed through this PR), or
# version conflicts for requests and six (fixed in steps above, to be included in this PR)
datacats install modena

# still running into Docker permissions bug: can't write to folders inside container
datacats start modena --address=0.0.0.0
```
Docker permissions bug: 
ckan-galleries creates a flickrapi instance, which creates a local (=inside the docker container) folder to store oauth tokens. The [docker-bug](https://github.com/docker/docker/issues/1295) is prorbably to do with stricter aufs permissions restricting their way up through the snapshot layers and strangling  flickrapi's attempt to create a folder `/root/.flickrapi`. This one's gonna be messy.

Re package dependencies, where does a datacats envorinment's `ckan/requirements.txt` come from, and can I update the requirements there?