### PR TITLE
Add more checks for datapusher.

### DIFF
--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -356,7 +356,8 @@ class Environment(object):
         cp = SafeConfigParser()
         try:
             cp.read(self.target + '/development.ini')
-            return 'datapusher' in cp.get('app:main', 'ckan.plugins')
+            return ('datapusher' in cp.get('app:main', 'ckan.plugins')
+                    and isdir(self.target + '/datapusher'))
         except ConfigParserError as e:
             raise DatacatsError('Failed to read and parse development.ini: ' + str(e))
 


### PR DESCRIPTION
Issues were happening where users who had their datapusher hosted somewhere else (not with Datacats) would have datapusher start up and fail because the datapusher source directory didn't exist. Therefore we now check for the datapusher directory in addition to the ckan.plugins.