### PR TITLE
Adding proper support of log_syslog option to aggregate all the datacats container logs in host's syslog

### DIFF
--- a/datacats/docker.py
+++ b/datacats/docker.py
@@ -238,16 +238,20 @@ def run_container(name, image, command=None, environment=None,
     """
     Wrapper for docker create_container, start calls
 
+    :param log_syslog: bool flag to redirect container's logs to host's syslog
+
     :returns: container info dict or None if container couldn't be created
 
     Raises PortAllocatedError if container couldn't start on the
     requested port.
     """
     binds = ro_rw_to_binds(ro, rw)
-
-    host_config = create_host_config(binds=binds,
-                                     log_config=LogConfig(
-                                         type=('syslog' if log_syslog else 'json-file')))
+    log_config = LogConfig(type=LogConfig.types.JSON)
+    if log_syslog:
+        log_config = LogConfig(
+            type=LogConfig.types.SYSLOG,
+            config={'syslog-tag': name})
+    host_config = create_host_config(binds=binds, log_config=log_config)
 
     c = _get_docker().create_container(
         name=name,

--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -249,7 +249,7 @@ class Environment(object):
         """
         task.create_source(self.target, self._preload_image(), datapusher)
 
-    def start_supporting_containers(self, log_syslog=Flase):
+    def start_supporting_containers(self, log_syslog=False):
         """
         Start all supporting containers (containers required for CKAN to
         operate) if they aren't already running.

--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -253,7 +253,12 @@ class Environment(object):
         """
         Start all supporting containers (containers required for CKAN to
         operate) if they aren't already running.
+
+            :param log_syslog: A flag to redirect all container logs to host's syslog
+
         """
+        log_syslog = True if self.always_prod else log_syslog
+        # in production we always use log_syslog driver (to aggregate all the logs)
         task.start_supporting_containers(
             self.sitedir,
             self.target,
@@ -388,6 +393,8 @@ class Environment(object):
         self.stop_ckan()
 
         port = self.port
+        # in prod we always use log_syslog driver
+        log_syslog = True if self.always_prod else log_syslog
 
         production = production or self.always_prod
         override_site_url = self.address == '127.0.0.1' and not is_boot2docker()

--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -249,21 +249,29 @@ class Environment(object):
         """
         task.create_source(self.target, self._preload_image(), datapusher)
 
-    def start_supporting_containers(self):
+    def start_supporting_containers(self, log_syslog=Flase):
         """
         Start all supporting containers (containers required for CKAN to
         operate) if they aren't already running.
         """
-        task.start_supporting_containers(self.sitedir, self.target,
-            self.passwords, self._get_container_name, self.extra_containers)
+        task.start_supporting_containers(
+            self.sitedir,
+            self.target,
+            self.passwords,
+            self._get_container_name,
+            self.extra_containers,
+            log_syslog=log_syslog
+            )
 
-    def stop_supporting_containers(self):
+    def stop_supporting_containers(self, log_syslog=False):
         """
         Stop and remove supporting containers (containers that are used by CKAN but don't host
         CKAN or CKAN plugins). This method should *only* be called after CKAN has been stopped
         or behaviour is undefined.
         """
         task.stop_supporting_containers(self._get_container_name, self.extra_containers)
+        task.stop_supporting_containers(self._get_container_name)
+
 
     def fix_storage_permissions(self):
         """

--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -263,15 +263,13 @@ class Environment(object):
             log_syslog=log_syslog
             )
 
-    def stop_supporting_containers(self, log_syslog=False):
+    def stop_supporting_containers(self):
         """
         Stop and remove supporting containers (containers that are used by CKAN but don't host
         CKAN or CKAN plugins). This method should *only* be called after CKAN has been stopped
         or behaviour is undefined.
         """
         task.stop_supporting_containers(self._get_container_name, self.extra_containers)
-        task.stop_supporting_containers(self._get_container_name)
-
 
     def fix_storage_permissions(self):
         """
@@ -397,7 +395,6 @@ class Environment(object):
 
         if address != '127.0.0.1' and is_boot2docker():
             raise DatacatsError('Cannot specify address on boot2docker.')
-
 
         # XXX nasty hack, remove this once we have a lessc command
         # for users (not just for building our preload image)

--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -373,9 +373,10 @@ class Environment(object):
         """
         Start the apache server or paster serve
 
-        :param production: True for apache, False for paster serve + debug on
         :param address: On Linux, the address to serve from (can be 0.0.0.0 for
                         listening on all addresses)
+        :param log_syslog: A flag to redirect all container logs to host's syslog
+        :param production: True for apache, False for paster serve + debug on
         :param paster_reload: Instruct paster to watch for file changes
         """
         self.stop_ckan()

--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -390,7 +390,6 @@ class Environment(object):
         if address != '127.0.0.1' and is_boot2docker():
             raise DatacatsError('Cannot specify address on boot2docker.')
 
-        datapusher = self.needs_datapusher()
 
         # XXX nasty hack, remove this once we have a lessc command
         # for users (not just for building our preload image)
@@ -408,6 +407,7 @@ class Environment(object):
         if not is_boot2docker():
             ro[self.datadir + '/venv'] = '/usr/lib/ckan'
 
+        datapusher = self.needs_datapusher()
         if datapusher:
             run_container(
                 self._get_container_name('datapusher'),

--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -414,7 +414,8 @@ class Environment(object):
                 'datacats/web',
                 '/scripts/datapusher.sh',
                 ro=ro,
-                volumes_from=(self._get_container_name('venv') if is_boot2docker() else None))
+                volumes_from=(self._get_container_name('venv') if is_boot2docker() else None),
+                log_syslog=log_syslog)
 
         while True:
             self._create_run_ini(port, production)

--- a/datacats/task.py
+++ b/datacats/task.py
@@ -487,7 +487,7 @@ def start_supporting_containers(sitedir, srcdir, passwords,
             image='datacats/solr',
             rw={sitedir + '/solr': '/var/lib/solr'},
             ro={srcdir + '/schema.xml': '/etc/solr/conf/schema.xml'},
-            log_syslog=log_config)
+            log_syslog=log_syslog)
 
         for container in extra_containers:
             # We don't know a whole lot about the extra containers so we're just gonna have to

--- a/datacats/task.py
+++ b/datacats/task.py
@@ -449,7 +449,7 @@ EXTRA_IMAGE_MAPPING = {'redis': 'redis'}
 
 
 def start_supporting_containers(sitedir, srcdir, passwords,
-        get_container_name, extra_containers):
+        get_container_name, extra_containers, log_syslog=False):
     """
     Start all supporting containers (containers required for CKAN to
     operate) if they aren't already running, along with some extra
@@ -479,13 +479,15 @@ def start_supporting_containers(sitedir, srcdir, passwords,
             image='datacats/postgres',
             environment=passwords,
             rw=rw,
-            volumes_from=volumes_from)
+            volumes_from=volumes_from,
+            log_syslog=log_syslog)
 
         docker.run_container(
             name=get_container_name('solr'),
             image='datacats/solr',
             rw={sitedir + '/solr': '/var/lib/solr'},
-            ro={srcdir + '/schema.xml': '/etc/solr/conf/schema.xml'})
+            ro={srcdir + '/schema.xml': '/etc/solr/conf/schema.xml'},
+            log_syslog=log_config)
 
         for container in extra_containers:
             # We don't know a whole lot about the extra containers so we're just gonna have to
@@ -497,7 +499,8 @@ def start_supporting_containers(sitedir, srcdir, passwords,
                 ro={
                     sitedir: '/datadir',
                     srcdir: '/project'
-                }
+                },
+                log_syslog=log_syslog
             )
 
 


### PR DESCRIPTION
## add log_syslog flag to things in datacats.task 
This adds log_syslog flag for all the container spanning functions (it was partially implemented already though, this one fixes gaps)


## turn it on for prod envs
use  log_syslog=True when Environment.always_prod=True


## assign syslog-tag
This assigns more descriptive syslog-tags when log_syslog=True.

Docker supports log-drivers: a config option for containers that enables redirecting that
container's logs somewhere else (as opposed to just dumping them in a json file
within the container's directory).

We have a flag to support syslog log-driver for new containers.
However, by default the source field of the log entry would only include container IDs
which is not very helpful when browsing the logs. Container names or something of this sort would have been much more helpful.

One can do it Docker 1.8 and higher by using the custom syslog tags feature,
where we assign the corresponding docker log option value (--log-opt). This thing uses that
and assigns container name for all cases when syslog log-driver is turned on.
