### PR TITLE
Add an option to specify the site_url

### DIFF
--- a/datacats/cli/create.py
+++ b/datacats/cli/create.py
@@ -34,7 +34,7 @@ Options:
   -n --no-sysadmin        Don't prompt for an initial sysadmin user account
   -s --site=NAME          Pick a site to create [default: primary]
   --no-datapusher         Don't install/enable ckanext-datapusher
-  --site-url SITE_URL     The site_url to use in API responses
+  --site-url SITE_URL     The site_url to use in API responses (e.x. http://myhostname.org:{port}/)
   --syslog                Log to the syslog
 
 ENVIRONMENT_DIR is a path for the new environment directory. The last
@@ -150,7 +150,7 @@ Options:
   -i --image-only         Create the environment but don't start containers
   -n --no-sysadmin        Don't prompt for an initial sysadmin user account
   -s --site=NAME          Pick a site to initialize [default: primary]
-  --site-url SITE_URL     The site_url to use in API responses
+  --site-url SITE_URL     The site_url to use in API responses (e.x. http://myhostname.org:{port}/)
   --syslog                Log to the syslog
 
 ENVIRONMENT_DIR is an existing datacats environment directory. Defaults to '.'

--- a/datacats/cli/create.py
+++ b/datacats/cli/create.py
@@ -34,7 +34,7 @@ Options:
   -n --no-sysadmin        Don't prompt for an initial sysadmin user account
   -s --site=NAME          Pick a site to create [default: primary]
   --no-datapusher         Don't install/enable ckanext-datapusher
-  --site-url SITE_URL     The site_url to use in API responses (e.x. http://myhostname.org:{port}/)
+  --site-url SITE_URL     The site_url to use in API responses (e.x. http://example.org:{port}/)
   --syslog                Log to the syslog
 
 ENVIRONMENT_DIR is a path for the new environment directory. The last
@@ -150,7 +150,7 @@ Options:
   -i --image-only         Create the environment but don't start containers
   -n --no-sysadmin        Don't prompt for an initial sysadmin user account
   -s --site=NAME          Pick a site to initialize [default: primary]
-  --site-url SITE_URL     The site_url to use in API responses (e.x. http://myhostname.org:{port}/)
+  --site-url SITE_URL     The site_url to use in API responses (e.x. http://example.org:{port}/)
   --syslog                Log to the syslog
 
 ENVIRONMENT_DIR is an existing datacats environment directory. Defaults to '.'

--- a/datacats/cli/create.py
+++ b/datacats/cli/create.py
@@ -34,7 +34,7 @@ Options:
   -n --no-sysadmin        Don't prompt for an initial sysadmin user account
   -s --site=NAME          Pick a site to create [default: primary]
   --no-datapusher         Don't install/enable ckanext-datapusher
-  --site-url SITE_URL     The site_url to use in API responses (e.x. http://example.org:{port}/)
+  --site-url SITE_URL     The site_url to use in API responses (e.g. http://example.org:{port}/)
   --syslog                Log to the syslog
 
 ENVIRONMENT_DIR is a path for the new environment directory. The last
@@ -150,7 +150,7 @@ Options:
   -i --image-only         Create the environment but don't start containers
   -n --no-sysadmin        Don't prompt for an initial sysadmin user account
   -s --site=NAME          Pick a site to initialize [default: primary]
-  --site-url SITE_URL     The site_url to use in API responses (e.x. http://example.org:{port}/)
+  --site-url SITE_URL     The site_url to use in API responses (e.g. http://example.org:{port}/)
   --syslog                Log to the syslog
 
 ENVIRONMENT_DIR is an existing datacats environment directory. Defaults to '.'

--- a/datacats/cli/manage.py
+++ b/datacats/cli/manage.py
@@ -54,7 +54,7 @@ Options:
   -s --site=NAME        Specify a site to start [default: primary]
   --syslog              Log to the syslog
   --site-url SITE_URL   The site_url to use in API responses. Defaults to old setting or
-                        will attempt to determine it. (e.g. http://myrandomhostname.org:{port}/)
+                        will attempt to determine it. (e.g. http://example.org:{port}/)
 
 ENVIRONMENT may be an environment name or a path to an environment directory.
 Default: '.'
@@ -80,7 +80,7 @@ Usage:
 Options:
   --address=IP          Address to listen on (Linux-only) [default: 127.0.0.1]
   --site-url=SITE_URL   The site_url to use in API responses. Can use Python template syntax
-                        to insert the port and address (e.g. http://myrandomhostname.org:{port}/)
+                        to insert the port and address (e.g. http://example.org:{port}/)
   -b --background       Don't wait for response from web server
   --no-watch            Do not automatically reload templates and .py files on change
   -p --production       Reload with apache and debug=false

--- a/datacats/cli/manage.py
+++ b/datacats/cli/manage.py
@@ -54,7 +54,7 @@ Options:
   -s --site=NAME        Specify a site to start [default: primary]
   --syslog              Log to the syslog
   --site-url SITE_URL   The site_url to use in API responses. Defaults to old setting or
-                        will attempt to determine it.
+                        will attempt to determine it. (e.g. http://myrandomhostname.org:{port}/)
 
 ENVIRONMENT may be an environment name or a path to an environment directory.
 Default: '.'
@@ -80,7 +80,7 @@ Usage:
 Options:
   --address=IP          Address to listen on (Linux-only) [default: 127.0.0.1]
   --site-url=SITE_URL   The site_url to use in API responses. Can use Python template syntax
-                        to insert the port and address (e.g. http://{address}:{port}/)
+                        to insert the port and address (e.g. http://myrandomhostname.org:{port}/)
   -b --background       Don't wait for response from web server
   --no-watch            Do not automatically reload templates and .py files on change
   -p --production       Reload with apache and debug=false

--- a/datacats/cli/manage.py
+++ b/datacats/cli/manage.py
@@ -44,13 +44,15 @@ Usage:
   datacats start -r [-b] [-s NAME] [--syslog] [--address=IP] [ENVIRONMENT]
 
 Options:
-  --address=IP       Address to listen on (Linux-only) [default: 127.0.0.1]
-  -b --background    Don't wait for response from web server
-  --no-watch         Do not automatically reload templates and .py files on change
-  -p --production    Start with apache and debug=false
-  -r --remote        Start DataCats.com cloud instance
-  -s --site=NAME     Specify a site to start [default: primary]
-  --syslog           Log to the syslog
+  --address=IP          Address to listen on (Linux-only) [default: 127.0.0.1]
+  -b --background       Don't wait for response from web server
+  --no-watch            Do not automatically reload templates and .py files on change
+  -p --production       Start with apache and debug=false
+  -r --remote           Start DataCats.com cloud instance
+  -s --site=NAME        Specify a site to start [default: primary]
+  --syslog              Log to the syslog
+  --site-url SITE_URL   The site_url to use in API responses. Defaults to old setting or
+                        will attempt to determine it.
 
 ENVIRONMENT may be an environment name or a path to an environment directory.
 Default: '.'
@@ -68,28 +70,41 @@ def reload_(environment, opts):
     """Reload environment source and configuration
 
 Usage:
-  datacats reload [-b] [-p|--no-watch] [--syslog] [-s NAME] [--address=IP] [ENVIRONMENT [PORT]]
-  datacats reload -r [-b] [--syslog] [-s NAME] [--address=IP] [ENVIRONMENT]
+  datacats reload [-b] [-p|--no-watch] [--syslog] [-s NAME] [--site-url=SITE_URL]
+                            [--address=IP] [ENVIRONMENT [PORT]]
+  datacats reload -r [-b] [--syslog] [-s NAME] [--address=IP] [--site-url=SITE_URL]
+                            [ENVIRONMENT]
 
 Options:
-  --address=IP       Address to listen on (Linux-only) [default: 127.0.0.1]
-  -b --background    Don't wait for response from web server
-  --no-watch         Do not automatically reload templates and .py files on change
-  -p --production    Reload with apache and debug=false
-  -r --remote        Reload DataCats.com cloud instance
-  -s --site=NAME     Specify a site to reload [default: primary]
-  --syslog           Log to the syslog
+  --address=IP          Address to listen on (Linux-only) [default: 127.0.0.1]
+  --site-url=SITE_URL   The site_url to use in API responses. Can use Python template syntax
+                        to insert the port and address (e.g. http://{address}:{port}/)
+  -b --background       Don't wait for response from web server
+  --no-watch            Do not automatically reload templates and .py files on change
+  -p --production       Reload with apache and debug=false
+  -r --remote           Reload DataCats.com cloud instance
+  -s --site=NAME        Specify a site to reload [default: primary]
+  --syslog              Log to the syslog
 
 ENVIRONMENT may be an environment name or a path to an environment directory.
 Default: '.'
 """
     environment.require_data()
     environment.stop_ckan()
-    if opts['PORT'] or opts['--address'] != '127.0.0.1':
+    if opts['PORT'] or opts['--address'] != '127.0.0.1' or opts['--site-url']:
         if opts['PORT']:
             environment.port = int(opts['PORT'])
         if opts['--address'] != '127.0.0.1':
             environment.address = opts['--address']
+        if opts['--site-url']:
+            site_url = opts['--site-url']
+            # TODO: Check it against a regex or use urlparse
+            try:
+                site_url = site_url.format(address=environment.address, port=environment.port)
+                environment.site_url = site_url
+                environment.save_site(False)
+            except (KeyError, IndexError, ValueError) as e:
+                raise DatacatsError('Could not parse site_url: {}'.format(e))
         environment.save()
     if 'postgres' not in environment.containers_running():
         environment.stop_supporting_containers()
@@ -99,7 +114,7 @@ Default: '.'
         production=opts['--production'],
         address=opts['--address'],
         paster_reload=not opts['--no-watch'],
-        log_syslog=opts['--syslog'])
+        log_syslog=opts['--syslog'],)
     write('Starting web server at {0} ...'.format(environment.web_address()))
     if opts['--background']:
         write('\n')

--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -384,7 +384,13 @@ class Environment(object):
         port = self.port
 
         production = production or self.always_prod
-        override_site_url = self.address == '127.0.0.1' and not is_boot2docker()
+        # We only override the site URL with the docker URL on three conditions
+        # 1 - we're listening on 127.0.0.1
+        override_site_url = (self.address == '127.0.0.1'
+                             # 2 - we're not using boot2docker
+                             and not is_boot2docker()
+                             # 3 - the site url is NOT set.
+                             and not self.site_url)
         command = ['/scripts/web.sh', str(production), str(override_site_url), str(paster_reload)]
 
         if address != '127.0.0.1' and is_boot2docker():

--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -77,13 +77,14 @@ class Environment(object):
             self.sites = task.list_sites(self.datadir)
         return self.sites
 
-    def save_site(self):
+    def save_site(self, create=True):
         """
         Save environment settings in the directory that need to be saved
         even when creating only a new sub-site env.
         """
         self._load_sites()
-        self.sites.append(self.site_name)
+        if create:
+            self.sites.append(self.site_name)
 
         task.save_new_site(self.site_name, self.sitedir, self.target, self.port,
             self.address, self.site_url, self.passwords)

--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -385,11 +385,8 @@ class Environment(object):
 
         production = production or self.always_prod
         # We only override the site URL with the docker URL on three conditions
-        # 1 - we're listening on 127.0.0.1
         override_site_url = (self.address == '127.0.0.1'
-                             # 2 - we're not using boot2docker
                              and not is_boot2docker()
-                             # 3 - the site url is NOT set.
                              and not self.site_url)
         command = ['/scripts/web.sh', str(production), str(override_site_url), str(paster_reload)]
 


### PR DESCRIPTION
Since the port is (typically) determined by Datacats at runtime, along with sometimes the address, we provide templating on the site_url through the Python format() syntax.

Addresses #253. (Hopefully)