### PR TITLE
Cli progress bar and generilized progress tracking for datacats commands

### DIFF
--- a/datacats/cli/create.py
+++ b/datacats/cli/create.py
@@ -12,7 +12,7 @@ from datacats.environment import Environment
 from datacats.cli.install import install_all
 from datacats.error import DatacatsError
 
-from datacats.cli.util import CliProgressTracker, y_or_n_prompt, confirm_password, function_as_step
+from datacats.cli.util import CLIProgressTracker, y_or_n_prompt, confirm_password, function_as_step
 
 
 def write(s):
@@ -93,7 +93,7 @@ def create_environment(environment_dir, port, ckan_version, create_skin,
 
         if not progress_tracker:
             # by default we use a cli progress tracker
-            progress_tracker = CliProgressTracker(
+            progress_tracker = CLIProgressTracker(
                 task_title='Creating datacats site environment',
                 total=len(steps),
                 quiet=quiet)

--- a/datacats/cli/util.py
+++ b/datacats/cli/util.py
@@ -30,3 +30,91 @@ def y_or_n_prompt(statement_of_risk):
 def require_extra_image(image_name):
     if not docker.image_exists(image_name):
         pull_image(image_name)
+
+
+class CliProgressTracker(object):
+    """
+    CliProgressTracker helps render a TTY progress bar
+    and show progress to the user.
+
+    The update_state function signature is similar to the one
+    that is used by celery so the advantage is that
+    functions that use this progress progress bar
+    can be tied up to celery easily.
+
+    Here is an example of use:
+        with CliProgressTracker(
+            task_title="", total=13) as pt:
+            for i in range(14):
+                pt.update_state(
+                    state='PROGRESS',
+                    meta={
+                        'current': i,
+                        'total': 13,
+                        'status':'sup'}
+                    )
+    """
+    BAR_TEMPLATE = "{title} : [{filled_bar}{empty_bar}] {percent}% : {status}..."
+    symbol_width = 50
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.clean_up()
+        return False  # not surpressing exceptions
+
+    def __init__(self, task_title, total=100, stream=sys.stderr):
+        self.current = 0
+        self.title = task_title
+        self.total = total
+        self.status = "Starting"
+        self.stream = stream
+        # when updating message we need to make sure we overwite the prev one
+        # with the same number of symbols (as tty sucks as a UI)
+        # so will store len of prev message too
+        self.prev_sym_len = 0
+        self.rendered = False
+        self.stream.write("\n")
+        self.show()
+
+    def update_state(self, state='PROGRESS', meta=None):
+        """
+         Update the state of the progress bar.
+        """
+        if not (state == 'PROGRESS'):
+            self.clean_up()
+            return
+        if not meta:
+            return
+        self.current = meta.get('current', self.current)
+        if 'status' in meta:
+            self.prev_status_len = len(self.status)
+            self.status = meta.get('status')
+        self.show()
+
+    def show(self):
+        percent = int(100.0 * float(self.current) / float(self.total))
+        filled_bar_num = int(self.symbol_width * float(percent) / 100.0)
+        empty_bar_num = self.symbol_width - filled_bar_num
+        output_str = self.BAR_TEMPLATE.format(
+            title=self.title,
+            filled_bar="=" * filled_bar_num,
+            empty_bar=" " * empty_bar_num,
+            percent=percent,
+            status=self.status
+        )
+        self.stream.write(output_str)
+        if len(output_str) < self.prev_sym_len:
+            self.stream.write(" " * (self.prev_sym_len - len(output_str)))
+        self.prev_sym_len = len(output_str)
+        self.stream.write("\r")
+
+    def clean_up(self):
+        """
+        Clean up after the progress bar by
+        overwriting whatever was printed so far with white spaces
+        """
+        self.stream.write(" " * self.prev_sym_len)
+        self.prev_sym_len = 0
+        self.stream.write("\r\b")

--- a/datacats/cli/util.py
+++ b/datacats/cli/util.py
@@ -32,7 +32,7 @@ def require_extra_image(image_name):
         pull_image(image_name)
 
 
-class CliProgressTracker(object):
+class CLIProgressTracker(object):
     """
     CliProgressTracker helps render a TTY progress bar
     and show progress to the user.

--- a/datacats/cli/util.py
+++ b/datacats/cli/util.py
@@ -109,6 +109,7 @@ class CliProgressTracker(object):
             self.stream.write(" " * (self.prev_sym_len - len(output_str)))
         self.prev_sym_len = len(output_str)
         self.stream.write("\r")
+        self.stream.flush()
 
     def clean_up(self):
         """
@@ -118,3 +119,4 @@ class CliProgressTracker(object):
         self.stream.write(" " * self.prev_sym_len)
         self.prev_sym_len = 0
         self.stream.write("\r\b")
+        self.stream.flush()

--- a/datacats/cli/util.py
+++ b/datacats/cli/util.py
@@ -64,7 +64,10 @@ class CliProgressTracker(object):
         self.clean_up()
         return False  # not surpressing exceptions
 
-    def __init__(self, task_title, total=100, stream=sys.stderr):
+    def __init__(self, task_title, total=100, stream=sys.stderr, quiet=False):
+        self.quiet = quiet
+        if self.quiet:
+            return
         self.current = 0
         self.title = task_title
         self.total = total
@@ -84,6 +87,8 @@ class CliProgressTracker(object):
         """
         if not (state == 'PROGRESS'):
             self.clean_up()
+            return
+        if self.quiet:
             return
         if not meta:
             return
@@ -116,6 +121,8 @@ class CliProgressTracker(object):
         Clean up after the progress bar by
         overwriting whatever was printed so far with white spaces
         """
+        if self.quiet:
+            return
         self.stream.write(" " * self.prev_sym_len)
         self.prev_sym_len = 0
         self.stream.write("\r\b")

--- a/datacats/cli/util.py
+++ b/datacats/cli/util.py
@@ -125,5 +125,24 @@ class CliProgressTracker(object):
             return
         self.stream.write(" " * self.prev_sym_len)
         self.prev_sym_len = 0
-        self.stream.write("\r\b")
+        self.stream.write("\r")
         self.stream.flush()
+
+
+def function_as_step(func, description=None):
+    """
+    Returns a tuple of function and first string of docstring
+    to provide the user is some details on what the function does
+
+    For procedures with a lot of steps or that take a long time
+    one would like to print out a status message
+    to the user to provide her with more details of
+    what is going on.
+    """
+    if description:
+        return func, description
+    if func.__doc__:
+        doc_lines = func.__doc__.split('\n')
+        if len(doc_lines) > 0:
+            return func, doc_lines[1].lstrip().rstrip()
+    return func, func.__name__

--- a/datacats/environment.py
+++ b/datacats/environment.py
@@ -205,8 +205,8 @@ class Environment(object):
 
     def create_bash_profile(self):
         """
-        Create a default .bash_profile for the shell user that
-        activates the ckan virtualenv
+        Create a default .bash_profile
+        for the shell user that activates the ckan virtualenv
         """
         with open(self.target + '/.bash_profile', 'w') as prof:
             prof.write('source /usr/lib/ckan/bin/activate\n')

--- a/datacats/tests/test_cli_progress_bar.py
+++ b/datacats/tests/test_cli_progress_bar.py
@@ -1,0 +1,26 @@
+import unittest
+
+from datacats.cli.util import CliProgressTracker
+import random
+
+
+class TestCliProgressTracker(unittest.TestCase):
+    def test_progress_tracker(self):
+        with CliProgressTracker(
+            task_title="Title for test progress bar",
+            total=13) as pt:
+            for i in range(14):
+                pt.update_state(
+                    state='PROGRESS',
+                    meta={
+                        'current': i,
+                        'total': 13,
+                        'status': 'wo' * random.randint(3, 14)}
+                    )
+            pt.update_state(
+                state='BANANA',
+                meta={
+                    'current': 12,
+                    'total': 13,
+                    'status': 'wo' * random.randint(3, 14)}
+                )


### PR DESCRIPTION
Potentially it is possible to call the datacats commands in environments beyond the interactive cli. For example, commands can be put in a Celery queue .

For these reasons, it would help to generalize the progress tracking to support other running contexts. At the moment the commands report their progress just by printing dots and progress messages to `stderr`. A transition is needed to a more generic approach.

This PR suggest one. 

We add `progress_tracker` key argument to our datacats command implementations. If none passed, by default, we use the CliProgressTracker that generates a nice-looking tty progress bar for the user. 

However, it is also easy to make and use custom progress tracker as well. The commands only call
the `update_state` method to communicate their stage. It goes like this:
```python
progress_tracker.update_state(state='PROGRESS',
                    meta={
                        'current': 20,
                        'total': 100,
                        'status': 'Making sandwiches'}
     )
                    
```
note  that this interface is identical to the one Celery uses.
