### PR TITLE
Refactor datacats so that it can be used as a package

### DIFF
--- a/datacats/__init__.py
+++ b/datacats/__init__.py
@@ -1,0 +1,1 @@
+from commands import *

--- a/datacats/cli/create.py
+++ b/datacats/cli/create.py
@@ -8,12 +8,10 @@ import sys
 import types
 from os.path import abspath
 
-from datacats.environment import Environment
-from datacats.cli.install import install_all
+import datacats
 from datacats.error import DatacatsError
 
-from datacats.cli.util import CLIProgressTracker, y_or_n_prompt, confirm_password, function_as_step
-
+from datacats.cli.util import CLIProgressTracker, y_or_n_prompt, confirm_password
 
 def write(s):
     sys.stdout.write(s)
@@ -41,7 +39,11 @@ Options:
 ENVIRONMENT_DIR is a path for the new environment directory. The last
 part of this path will be used as the environment name.
 """
-    return create_environment(
+
+    progress_tracker = CLIProgressTracker(
+        task_title='Creating datacats site environment')
+
+    return datacats.create(
         environment_dir=opts['ENVIRONMENT_DIR'],
         port=opts['PORT'],
         create_skin=not opts['--bare'],
@@ -53,72 +55,10 @@ part of this path will be used as the environment name.
         log_syslog=opts['--syslog'],
         datapusher=not opts['--no-datapusher'],
         site_url=opts['--site-url'],
+        progress_tracker=progress_tracker
         )
 
 
-def create_environment(environment_dir, port, ckan_version, create_skin,
-        site_name, start_web, create_sysadmin, address, log_syslog=False,
-        datapusher=True, quiet=False, site_url=None, progress_tracker=None):
-    environment = Environment.new(environment_dir, ckan_version, site_name,
-                                  address=address, port=port)
-
-    try:
-        # There are a lot of steps we can/must skip if we're making a sub-site only
-        making_full_environment = not environment.data_exists()
-
-        steps = [
-            function_as_step(
-                lambda: environment.create_directories(making_full_environment),
-                description="Create the directories"),
-            function_as_step(environment.create_bash_profile)
-            ] + \
-            ([
-                function_as_step(environment.create_virtualenv),
-                function_as_step(environment.save),
-                function_as_step(lambda: environment.create_source(datapusher),
-                    description="Create source"),
-                function_as_step(environment.create_ckan_ini)] if making_full_environment else []
-            ) + \
-            [
-                function_as_step(environment.save_site),
-                function_as_step(environment.start_supporting_containers),
-                function_as_step(environment.fix_storage_permissions),
-                function_as_step(
-                    lambda: environment.update_ckan_ini(skin=create_skin),
-                    description="Create ckan INI file"),
-            ]
-
-        if create_skin and making_full_environment:
-            steps.append(function_as_step(environment.create_install_template_skin))
-
-        if not progress_tracker:
-            # by default we use a cli progress tracker
-            progress_tracker = CLIProgressTracker(
-                task_title='Creating datacats site environment',
-                total=len(steps),
-                quiet=quiet)
-        for step_num, step in enumerate(steps):
-            if not isinstance(step, types.FunctionType):
-                fn, descr = step
-            else:
-                fn, descr = step, "Please Wait"
-            progress_tracker.update_state(
-                state='PROGRESS',
-                meta={
-                    'current': step_num,
-                    'total': len(steps),
-                    'status': descr
-                })
-            fn()
-        if hasattr(progress_tracker, "clean_up"):
-            progress_tracker.clean_up()
-
-        finish_init(environment, start_web, create_sysadmin, address,
-           log_syslog=log_syslog, site_url=site_url)
-    except:
-        if hasattr(progress_tracker, "clean_up"):
-            progress_tracker.clean_up()
-        raise
 
 
 def reset(environment, opts):
@@ -223,43 +163,3 @@ ENVIRONMENT_DIR is an existing datacats environment directory. Defaults to '.'
     return finish_init(environment, start_web, create_sysadmin, address,
                        log_syslog=log_syslog, do_install=not no_install,
                        quiet=quiet, site_url=site_url)
-
-
-def finish_init(environment, start_web, create_sysadmin, address, log_syslog=False,
-                do_install=True, quiet=False, site_url=None):
-    """
-    Common parts of create and init: Install, init db, start site, sysadmin
-    """
-    if do_install:
-        install_all(environment, False, verbose=False, quiet=quiet)
-
-    if not quiet:
-        write('Initializing database')
-    environment.install_postgis_sql()
-    environment.ckan_db_init()
-    if not quiet:
-        write('\n')
-
-    if site_url:
-        try:
-            site_url = site_url.format(address=environment.address, port=environment.port)
-            environment.site_url = site_url
-            environment.save_site(False)
-        except (KeyError, IndexError, ValueError) as e:
-            raise DatacatsError('Could not parse site_url: {}'.format(e))
-
-    if start_web:
-        environment.start_ckan(address=address, log_syslog=log_syslog)
-        if not quiet:
-            write('Starting web server at {0} ...\n'.format(
-                environment.web_address()))
-
-    if create_sysadmin:
-        try:
-            adminpw = confirm_password()
-            environment.create_admin_set_password(adminpw)
-        except KeyboardInterrupt:
-            print
-
-    if not start_web:
-        environment.stop_supporting_containers()

--- a/datacats/cli/create.py
+++ b/datacats/cli/create.py
@@ -12,6 +12,8 @@ import datacats
 from datacats.error import DatacatsError
 
 from datacats.cli.util import CLIProgressTracker, y_or_n_prompt, confirm_password
+from datacats.task import finish_init
+
 
 def write(s):
     sys.stdout.write(s)

--- a/datacats/cli/install.py
+++ b/datacats/cli/install.py
@@ -4,12 +4,7 @@
 # the terms of the GNU Affero General Public License version 3.0.
 # See LICENSE.txt or http://www.fsf.org/licensing/licenses/agpl-3.0.html
 
-import sys
-from os import listdir
-from os.path import isdir, exists
 from datacats.docker import container_logs
-
-from clint.textui import colored
 
 from datacats.cli import manage
 from datacats.error import DatacatsError

--- a/datacats/cli/install.py
+++ b/datacats/cli/install.py
@@ -12,9 +12,9 @@ from datacats.docker import container_logs
 from clint.textui import colored
 
 from datacats.cli import manage
-from datacats.docker import check_connectivity
 from datacats.error import DatacatsError
 from datacats.environment import Environment
+import datacats.task
 
 
 def install(environment, opts):
@@ -32,7 +32,7 @@ ENVIRONMENT may be an environment name or a path to an environment directory.
 Default: '.'
 """
     environment.require_data()
-    install_all(environment, opts['--clean'], verbose=not opts['--quiet'])
+    datacats.task.install_all(environment, opts['--clean'], verbose=not opts['--quiet'])
 
     for site in environment.sites:
         environment = Environment.load(environment.name, site)
@@ -47,51 +47,6 @@ Default: '.'
                 '--syslog': False,
                 '--site-url': None
                 })
-
-
-def install_all(environment, clean, verbose=False, quiet=False):
-    logs = check_connectivity()
-    if logs.strip():
-        raise DatacatsError(logs)
-
-    srcdirs = set()
-    reqdirs = set()
-    for d in listdir(environment.target):
-        fulld = environment.target + '/' + d
-        if not isdir(fulld):
-            continue
-        if not exists(fulld + '/setup.py'):
-            continue
-        srcdirs.add(d)
-        if (exists(fulld + '/requirements.txt') or
-                exists(fulld + '/pip-requirements.txt')):
-            reqdirs.add(d)
-    try:
-        srcdirs.remove('ckan')
-        reqdirs.remove('ckan')
-    except KeyError:
-        raise DatacatsError('ckan not found in environment directory')
-
-    if clean:
-        environment.clean_virtualenv()
-        environment.install_extra()
-
-    for s in ['ckan'] + sorted(srcdirs):
-        if verbose:
-            print colored.yellow('Installing ' + s + '\n')
-        elif not quiet:
-            print 'Installing ' + s
-        environment.install_package_develop(s, sys.stdout if verbose and not quiet else None)
-        if verbose and not quiet:
-            print
-    for s in ['ckan'] + sorted(reqdirs):
-        if verbose:
-            print colored.yellow('Installing ' + s + ' requirements' + '\n')
-        elif not quiet:
-            print 'Installing ' + s + ' requirements'
-        environment.install_package_requirements(s, sys.stdout if verbose and not quiet else None)
-        if verbose:
-            print
 
 
 def _print_logs(c_id):

--- a/datacats/cli/util.py
+++ b/datacats/cli/util.py
@@ -77,7 +77,6 @@ class CLIProgressTracker(object):
         # with the same number of symbols (as tty sucks as a UI)
         # so will store len of prev message too
         self.prev_sym_len = 0
-        self.rendered = False
         self.stream.write("\n")
         self.show()
 
@@ -93,8 +92,8 @@ class CLIProgressTracker(object):
         if not meta:
             return
         self.current = meta.get('current', self.current)
+        self.total = meta.get('total', self.total)
         if 'status' in meta:
-            self.prev_status_len = len(self.status)
             self.status = meta.get('status')
         self.show()
 
@@ -127,22 +126,3 @@ class CLIProgressTracker(object):
         self.prev_sym_len = 0
         self.stream.write("\r")
         self.stream.flush()
-
-
-def function_as_step(func, description=None):
-    """
-    Returns a tuple of function and first string of docstring
-    to provide the user is some details on what the function does
-
-    For procedures with a lot of steps or that take a long time
-    one would like to print out a status message
-    to the user to provide her with more details of
-    what is going on.
-    """
-    if description:
-        return func, description
-    if func.__doc__:
-        doc_lines = func.__doc__.split('\n')
-        if len(doc_lines) > 0:
-            return func, doc_lines[1].lstrip().rstrip()
-    return func, func.__name__

--- a/datacats/commands.py
+++ b/datacats/commands.py
@@ -1,0 +1,14 @@
+# Copyright 2014-2015 Boxkite Inc.
+
+# This file is part of the DataCats package and is released under
+# the terms of the GNU Affero General Public License version 3.0.
+# See LICENSE.txt or http://www.fsf.org/licensing/licenses/agpl-3.0.html
+
+"""
+The commands module defines the datacats package's interface, that is
+all the commands the package implements as functions.
+
+The rest of the datacats package is
+ - implementation of these commands
+ - a shell wrapper of these commands for datacats-cli tool (see cli module)
+"""

--- a/datacats/commands.py
+++ b/datacats/commands.py
@@ -12,3 +12,59 @@ The rest of the datacats package is
  - implementation of these commands
  - a shell wrapper of these commands for datacats-cli tool (see cli module)
 """
+from datacats.environment import Environment
+from datacats.util import function_as_step, run_a_sequence_of_function_steps
+import task
+
+def create(environment_dir, port, ckan_version, create_skin,
+    site_name, start_web, create_sysadmin, address, log_syslog=False,
+    datapusher=True, site_url=None, progress_tracker=None):
+    environment = Environment.new(
+        environment_dir,
+        ckan_version,
+        site_name,
+        address=address,
+        port=port)
+    try:
+        # There are a lot of steps we can/must skip if we're making a sub-site only
+        making_full_environment = not environment.data_exists()
+
+        steps = [
+            function_as_step(
+                lambda: environment.create_directories(making_full_environment),
+                description="Create the directories"),
+            environment.create_bash_profile
+            ]
+        if making_full_environment:
+            steps += [
+                environment.create_virtualenv,
+                environment.save,
+                function_as_step(lambda: environment.create_source(datapusher),
+                    description="Create source"),
+                environment.create_ckan_ini]
+
+        steps += [
+                environment.save_site,
+                environment.start_supporting_containers,
+                environment.fix_storage_permissions,
+                function_as_step(
+                    lambda: environment.update_ckan_ini(skin=create_skin),
+                    description="Create ckan INI file")]
+
+        if create_skin and making_full_environment:
+            steps.append(environment.create_install_template_skin)
+
+        steps.append(function_as_step(
+            lambda: task.finish_init(
+                environment, start_web, create_sysadmin, address,
+                log_syslog=log_syslog, site_url=site_url),
+            description="Starting the site"))
+
+        run_a_sequence_of_function_steps(steps, progress_tracker=progress_tracker)
+        if hasattr(progress_tracker, "clean_up"):
+            progress_tracker.clean_up()
+
+    except:
+        if hasattr(progress_tracker, "clean_up"):
+            progress_tracker.clean_up()
+        raise

--- a/datacats/commands.py
+++ b/datacats/commands.py
@@ -16,6 +16,7 @@ from datacats.environment import Environment
 from datacats.util import function_as_step, run_a_sequence_of_function_steps
 import task
 
+
 def create(environment_dir, port, ckan_version, create_skin,
     site_name, start_web, create_sysadmin, address, log_syslog=False,
     datapusher=True, site_url=None, progress_tracker=None):
@@ -44,12 +45,12 @@ def create(environment_dir, port, ckan_version, create_skin,
                 environment.create_ckan_ini]
 
         steps += [
-                environment.save_site,
-                environment.start_supporting_containers,
-                environment.fix_storage_permissions,
-                function_as_step(
-                    lambda: environment.update_ckan_ini(skin=create_skin),
-                    description="Create ckan INI file")]
+            environment.save_site,
+            environment.start_supporting_containers,
+            environment.fix_storage_permissions,
+            function_as_step(
+                lambda: environment.update_ckan_ini(skin=create_skin),
+                description="Create ckan INI file")]
 
         if create_skin and making_full_environment:
             steps.append(environment.create_install_template_skin)

--- a/datacats/tests/test_cli_progress_bar.py
+++ b/datacats/tests/test_cli_progress_bar.py
@@ -1,12 +1,11 @@
 import unittest
 
-from datacats.cli.util import CliProgressTracker
+from datacats.cli.util import CLIProgressTracker
 import random
 
-
-class TestCliProgressTracker(unittest.TestCase):
+class TestCLIProgressTracker(unittest.TestCase):
     def test_progress_tracker(self):
-        with CliProgressTracker(
+        with CLIProgressTracker(
             task_title="Title for test progress bar",
             total=13) as pt:
             for i in range(14):
@@ -17,6 +16,7 @@ class TestCliProgressTracker(unittest.TestCase):
                         'total': 13,
                         'status': 'wo' * random.randint(3, 14)}
                     )
+
             pt.update_state(
                 state='BANANA',
                 meta={

--- a/datacats/util.py
+++ b/datacats/util.py
@@ -1,0 +1,59 @@
+"""
+module datacats.util contains small helper elements reused accross the package
+"""
+
+
+def function_as_step(func, description=None):
+    """
+    Returns a tuple of function and first string of docstring
+    to provide the user is some details on what the function does
+
+    For procedures with a lot of steps or that take a long time
+    one would like to print out a status message
+    to the user to provide her with more details of
+    what is going on.
+    """
+    if description:
+        return func, description
+    if func.__doc__:
+        doc_lines = func.__doc__.split('\n')
+        if len(doc_lines) > 0:
+            return func, doc_lines[1].lstrip().rstrip()
+    return func, func.__name__
+
+
+def run_a_sequence_of_function_steps(list_of_functions, progress_tracker=None):
+    """
+    Some procedures include several steps being run
+    we want to run them in a sequence and report progress
+    to the caller (which is done in generic way with ProgressTracker)
+
+    This accepts the list of functions and calls function_as_step on each
+    to try generating one-line description from docstring so that
+    the progress tracker can be updated with the status string.
+
+    Sometimes it maybe needed to define custom progress messages,
+    for example, when a step is defined with lambda function to also
+    specify function's arguments.
+
+    The suggested pattern then is to call function_as_step explicitely:
+            list_of_functions = [
+                 function_as_step(lambda: add(3,4),"Add two numbers")
+            ]
+    This function will recognize when the function_as_step has been called
+    on an item in the list.
+    """
+    for step_num, step in enumerate(list_of_functions):
+        if callable(step):
+            # also support list item being a tuple of a func and a status string
+            step = function_as_step(step)
+        func, descr = step
+        if progress_tracker:
+            progress_tracker.update_state(
+                state='PROGRESS',
+                meta={
+                    'current': step_num,
+                    'total': len(list_of_functions),
+                    'status': descr
+                })
+        func()


### PR DESCRIPTION
datacats has been made as a cli-tool. We now see that it can be extensively used as python package and the interface should be the sam as the datacats-cli. See discussion here for context: https://github.com/datacats/datacats/pull/272

This PR scaffolds this Le Refactoree Grandiouse:

* the create command has been properly moved to commands.py
* install_all and finish_init were moved to task.py as they don't belong to cli package

I am making a PR now so that you guys @wardi @JackMc could see it and provide the feedback on this approach. Once we settle on this, refactoring all the other commands should be straightforward enough.