### PR TITLE
datacats/postgres container: fix listen_address setter in postgresql.…

### DIFF
--- a/docker/postgres/ckan.sh
+++ b/docker/postgres/ckan.sh
@@ -23,6 +23,12 @@ EOSQL
 
 # Adjust PostgreSQL configuration so that remote connections to the
 # database are possible.
+
+set_listen_addresses() {
+	sedEscapedValue="$(echo "$1" | sed 's/[\/&]/\\&/g')"
+	sed -ri "s/^#?(listen_addresses\s*=\s*)\S+/\1'$sedEscapedValue'/" "/var/lib/postgresql/data/postgresql.conf"
+}
+
+listen_addresses '*'
 echo "local all  postgres    peer" >> /var/lib/postgresql/data/pg_hba.conf
 echo "host  all  all    0.0.0.0/0  md5" >> /var/lib/postgresql/data/pg_hba.conf
-echo "listen_addresses='*'" >> /var/lib/postgresql/data/postgresql.conf


### PR DESCRIPTION
`postgresql.conf` has `listen addresses` setting that is `localhost` by default and defines what connections the db-daemon accepts and listens to.

Instead of adding a needed line `localhost "*"` which results in the two conflicting lines setter, let's update the default value.

In the future we may want to set it up to the web container's IP only.