### PR TITLE
#334 revive datapusher using datawagovau/datapusher fork

### DIFF
--- a/docker/ckan/Dockerfile
+++ b/docker/ckan/Dockerfile
@@ -9,7 +9,7 @@ RUN virtualenv $CKAN_HOME && \
     mkdir -p $CKAN_HOME /project /var/www/storage && \
     chown -R www-data:www-data /var/www && \
     git clone --depth 1 --branch $BRANCH https://github.com/ckan/ckan /project/ckan && \
-    git clone --branch stable --depth 1 https://github.com/ckan/datapusher /project/datapusher && \
+    git clone --branch stable --depth 1 https://github.com/datawagovau/datapusher /project/datapusher && \
     $CKAN_HOME/bin/pip install -r /project/ckan/requirements.txt && \
     $CKAN_HOME/bin/pip install -e /project/ckan && \
     $CKAN_HOME/bin/pip install ckanapi && \


### PR DESCRIPTION
which uses datawagovau/ckanserviceprovider, which in turn does not hard-code SQLAlchemy and requests versions any more.

## Try
```
git clone https://github.com/datawagovau/datacats.git
datacats$ python setup.py install
datacats$ datacats pull -a
datacats/docker$ docker build -t datacats/ckan ckan/
```
## Pros
* uses datawagovau forks for datapusher and ckanserviceprovider
* datapusher works again (probably) or at least starts

## Cons
http://boom.alpha.data.wa.gov.au/ still blows up after login with AttributeError: 'Query' object has no attribute 'select_entity_from' where `/project/ckan/ckan/model/activity.py`L96 tries to get SQLAlchemy to `_union_all` activities for the user dashboard.

## Why
Trying to help @JackMc  @deniszgonjanin to fix #334 